### PR TITLE
ci: enable git-submodules manager on main

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,7 +58,8 @@
   ],
   "enabledManagers": [
     "npm",
-    "github-actions"
+    "github-actions",
+    "git-submodules"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
We enabled it in develop but renovate picks it's settings from the default branch of the repo by default.