### PR TITLE
fix(ui): fix missing Italics in Inter typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@ocial/frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@fontsource-variable/inter": "5.0.16",
         "@vueuse/components": "10.9.0",
         "@vueuse/core": "10.9.0",
         "axios": "1.6.7",
@@ -17,6 +16,7 @@
         "defu": "6.1.4",
         "destr": "2.0.3",
         "fast-equals": "5.0.1",
+        "inter-ui": "4.0.2",
         "radix-vue": "1.4.9",
         "vue": "3.4.21",
         "vue-i18n": "9.9.1",
@@ -1285,11 +1285,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.0.16.tgz",
-      "integrity": "sha512-k+BUNqksTL+AN+o+OV7ILeiE9B5M5X+/jA7LWvCwjbV9ovXTqZyKRhA/x7uYv/ml8WQ0XNLBM7cRFIx4jW0/hg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -5532,6 +5527,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inter-ui": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inter-ui/-/inter-ui-4.0.2.tgz",
+      "integrity": "sha512-YmfzwEtzuVzEenQwSB/tmmqi/A0a2GnFk4mG4ZFULXiO5DNk0fJWiO3o9i1sdVKuMVGx9iiNQnCq8ghWZJVVHw==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "unit-test": "true"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "5.0.16",
     "@vueuse/components": "10.9.0",
     "@vueuse/core": "10.9.0",
     "axios": "1.6.7",
@@ -39,6 +38,7 @@
     "defu": "6.1.4",
     "destr": "2.0.3",
     "fast-equals": "5.0.1",
+    "inter-ui": "4.0.2",
     "radix-vue": "1.4.9",
     "vue": "3.4.21",
     "vue-i18n": "9.9.1",

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1,6 +1,6 @@
 html {
   overscroll-behavior: none;
-  font-family: 'Inter Variable', sans-serif;
+  font-family: 'InterVariable', system-ui;
 }
 
 html.no-forced-scrollbar {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import { router } from '@/plugins/router';
 /**
  * - ESTILOS GLOBALES -
  */
-import '@fontsource-variable/inter';
+import 'inter-ui/inter-variable.css';
 import '@/assets/styles/global.css';
 import 'virtual:uno.css';
 


### PR DESCRIPTION
We're using now the author's npm package (which is more up to date than the Google version)