### PR TITLE
chore/dx: move outdated extensions to unwantedRecommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,17 +6,17 @@
     "aaron-bond.better-comments",
     "eamodio.gitlens",
     "vue.volar",
-    "vue.vscode-typescript-vue-plugin",
     "dbaeumer.vscode-eslint",
     "lokalise.i18n-ally",
     "ryanluker.vscode-coverage-gutters",
     "yoavbls.pretty-ts-errors",
     "SonarSource.sonarlint-vscode",
-    "Selemondev.shadcn-vue",
     "antfu.unocss"
   ],
   "unwantedRecommendations": [
     "octref.vetur",
+    "vue.vscode-typescript-vue-plugin",
+    "Selemondev.shadcn-vue",
     "esbenp.prettier-vscode"
   ]
 }


### PR DESCRIPTION
* Since [vue-tsc](https://github.com/vuejs/language-tools/releases/tag/v2.0.0) 2.0.0's update, there's no need for takeover mode, so the typescript extension is now deprecated.
* Since shadcn-vue forces us into a rather rigid stylesheet structure and also tailwind, and the extension expects a `components.json` file, the extension is no longer useful for us anymore. Now, what we do is go to the shadcn-vue's component page and navigate to the 'Manual' tab to write the components ourselves manually, without any automation. Since this is a process that needs to be done once per component, it's a minor annoyance.