### PR TITLE
fix: use hash router history

### DIFF
--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -2,7 +2,7 @@ import { useTitle } from '@vueuse/core';
 import { computed } from 'vue';
 import {
   createRouter,
-  createWebHistory
+  createWebHashHistory
 } from 'vue-router/auto';
 /**
  * TODO: Implementar cuando el login esté terminado
@@ -11,7 +11,7 @@ import { metaGuard } from './middlewares/meta';
 import { isStr } from '@/utils/validation';
 
 export const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   /**
    * TODO: Arreglar esto, de forma que solo se realice el scroll en cuanto Suspense resuelva
    */


### PR DESCRIPTION
Hash history is less appealing in the URLs but it's the most compatible way of handling routing, regardless the server configuration.

Currently, CloudFlare doesn't have proper configuration for SPA routing with HTML5 history mode.