### PR TITLE
fix: skip lib check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Bundler",
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "sourceMap": true,


### PR DESCRIPTION
Esto elimina todos los problemas que aparecía en VSCode y que estaban causados por librerías externas y no nuestro propio código