### PR TITLE
ci: remove recursive git cloning in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           show-progress: false
-          submodules: recursive
 
       - name: Initialize CodeQL 🛠️
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
By doing recursive cloning, CodeQL will give us warnings of code that doesn't belong to us.
This will automatically fix all the security warnings.